### PR TITLE
Change to use Keccak gem supporting Ruby 3.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     eip55 (1.0.0)
-      digest-sha3 (~> 1.1)
+      keccak (~> 1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -10,8 +10,8 @@ GEM
     ansi (1.5.0)
     ast (2.4.0)
     builder (3.2.3)
-    digest-sha3 (1.1.0)
     jaro_winkler (1.5.1)
+    keccak (1.3.1)
     minitest (5.11.3)
     minitest-reporters (1.3.0)
       ansi
@@ -35,7 +35,7 @@ GEM
     unicode-display_width (1.4.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-22
 
 DEPENDENCIES
   eip55!
@@ -44,4 +44,4 @@ DEPENDENCIES
   rubocop (~> 0.58)
 
 BUNDLED WITH
-   1.16.1
+   2.4.12

--- a/eip55.gemspec
+++ b/eip55.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "digest-sha3", "~> 1.1"
+  spec.add_dependency "keccak", "~> 1.3"
   spec.add_development_dependency "minitest", "~> 5.11"
   spec.add_development_dependency "minitest-reporters", "~> 1.3"
   spec.add_development_dependency "rubocop", "~> 0.58"

--- a/lib/eip55/util.rb
+++ b/lib/eip55/util.rb
@@ -8,7 +8,7 @@ module EIP55
       end
 
       def keccak256 buffer
-        Digest::SHA3.new(256).digest(buffer)
+        Digest::Keccak.new(256).digest(buffer)
       end
 
       def prefix address


### PR DESCRIPTION
The digest-sha3 gem does not support Ruby 3. This change swaps to using a fork of the digest-sha3 gem, keccak, which does have Ruby 3 support.